### PR TITLE
Format podcast description text

### DIFF
--- a/SEDaily-IOS/PodcastDescriptionView.swift
+++ b/SEDaily-IOS/PodcastDescriptionView.swift
@@ -40,7 +40,10 @@ class PodcastDescriptionView: UIView {
 
     func setupView(podcastModel: PodcastViewModel) {
         podcastModel.getHTMLDecodedDescription { (returnedString) in
-            self.label.text = returnedString
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.paragraphSpacing = 10
+
+            self.label.attributedText = NSAttributedString(string: returnedString, attributes: [NSAttributedStringKey.paragraphStyle: paragraphStyle])
             self.label.sizeToFit()
             self.height = self.label.height + self.bottomMarginForLabel
         }


### PR DESCRIPTION
I noticed the podcast description was a little cramped because there's no spacing between the paragraphs. I changed the podcast description from a String to an NSAttributedString with paragraph formatting. Now the description looks a little nicer and similar to how it looks on the Apple podcasts app. The spacing does sort of exaggerate line feeds though.

Let me know if you'd take a different approach. 