### PR TITLE
Add basic share button functionality as a reusable UIViewController that manages a UIButton

### DIFF
--- a/Constants/L10nEnum.swift
+++ b/Constants/L10nEnum.swift
@@ -63,6 +63,8 @@ enum L10n {
   static let passwordPlaceholder = L10n.tr("Localizable", "PasswordPlaceholder")
   /// Play
   static let play = L10n.tr("Localizable", "Play")
+  /// Share
+  static let share = L10n.tr("Localizable", "Share")
   /// Sign Up
   static let signUpButtonTitle = L10n.tr("Localizable", "SignUpButtonTitle")
   /// Just For You

--- a/SEDaily-IOS.xcodeproj/project.pbxproj
+++ b/SEDaily-IOS.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		1E638E561FC794AC00A29BDC /* ProgressIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E638E551FC794AC00A29BDC /* ProgressIndicator.swift */; };
 		238E99F4E37C7365658113B8 /* Pods_SEDaily_IOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DF0C9F051C6C2F8638D2ABF8 /* Pods_SEDaily_IOSTests.framework */; };
 		24412438C753126FDDD37CBF /* Pods_SEDaily_IOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A3651E5B02B83E392546E167 /* Pods_SEDaily_IOS.framework */; };
+		8F22502A2003440100FDF3F1 /* SharePodcastViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F2250292003440100FDF3F1 /* SharePodcastViewController.swift */; };
+		8F22502C2005B2D100FDF3F1 /* ShareButtonViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F22502B2005B2D100FDF3F1 /* ShareButtonViewController.swift */; };
 		C079B6541FCA07F800B4B304 /* HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C079B6531FCA07F800B4B304 /* HelpersTests.swift */; };
 		C0E64BB41FCB3F9100753AF0 /* UserModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E64BB31FCB3F9100753AF0 /* UserModelTests.swift */; };
 		C0E64BB71FCB406000753AF0 /* UserDefaultsMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0E64BB61FCB406000753AF0 /* UserDefaultsMock.swift */; };
@@ -105,6 +107,8 @@
 		1E44AF081F87B0A700221B22 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		1E638E551FC794AC00A29BDC /* ProgressIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressIndicator.swift; sourceTree = "<group>"; };
 		675FBEB71FD81FBA8767227A /* Pods-SEDaily-IOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SEDaily-IOS.release.xcconfig"; path = "Pods/Target Support Files/Pods-SEDaily-IOS/Pods-SEDaily-IOS.release.xcconfig"; sourceTree = "<group>"; };
+		8F2250292003440100FDF3F1 /* SharePodcastViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharePodcastViewController.swift; sourceTree = "<group>"; };
+		8F22502B2005B2D100FDF3F1 /* ShareButtonViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareButtonViewController.swift; sourceTree = "<group>"; };
 		995F64385352A79BA0DF7DEB /* Pods-SEDaily-IOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SEDaily-IOSTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SEDaily-IOSTests/Pods-SEDaily-IOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		9FDA28C254F62BB468401B75 /* Pods-SEDaily-IOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SEDaily-IOS.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SEDaily-IOS/Pods-SEDaily-IOS.debug.xcconfig"; sourceTree = "<group>"; };
 		A2EFA433B346D70E958FFC73 /* Pods-SEDaily-IOSTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SEDaily-IOSTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-SEDaily-IOSTests/Pods-SEDaily-IOSTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -228,7 +232,7 @@
 			isa = PBXGroup;
 			children = (
 				C0E64BB51FCB404B00753AF0 /* Mocks */,
-				1686FC151F009EC00088A6C1 /* SEDaily_IOSTests.swift */,
+				1686FC151F009EC00088A6C1 /* SEDailyIOSTests.swift */,
 				1686FC171F009EC00088A6C1 /* Info.plist */,
 				C079B6531FCA07F800B4B304 /* HelpersTests.swift */,
 				C0E64BB31FCB3F9100753AF0 /* UserModelTests.swift */,
@@ -285,6 +289,8 @@
 				164C71041F021AC8003803BC /* CustomTabViewController.swift */,
 				01BB1D6C1F29999E004A912E /* PodcastPageViewController.swift */,
 				1649A7891F204EC6005C4A6E /* ContainerViewController.swift */,
+				8F2250292003440100FDF3F1 /* SharePodcastViewController.swift */,
+				8F22502B2005B2D100FDF3F1 /* ShareButtonViewController.swift */,
 			);
 			name = CommonVCs;
 			sourceTree = "<group>";
@@ -393,7 +399,6 @@
 				TargetAttributes = {
 					1686FBFC1F009EC00088A6C1 = {
 						CreatedOnToolsVersion = 8.3.2;
-						DevelopmentTeam = 6TY8WC8WPP;
 						LastSwiftMigration = 0900;
 						ProvisioningStyle = Automatic;
 						SystemCapabilities = {
@@ -652,6 +657,7 @@
 				164FE9E11F02EE67009419CA /* LoginViewController.swift in Sources */,
 				1649A78A1F204EC6005C4A6E /* ContainerViewController.swift in Sources */,
 				164FE9EF1F03065C009419CA /* NavigationControllerExtension.swift in Sources */,
+				8F22502C2005B2D100FDF3F1 /* ShareButtonViewController.swift in Sources */,
 				165484551F902D3F005AEA23 /* GeneralCollectionViewController.swift in Sources */,
 				1E638E561FC794AC00A29BDC /* ProgressIndicator.swift in Sources */,
 				161F3DE61F61F73D00A8F825 /* SearchTableViewController.swift in Sources */,
@@ -671,6 +677,7 @@
 				166036211F266FF300A22B7B /* Notifications.swift in Sources */,
 				169806A61F8EF3970075D8AD /* L10nEnum.swift in Sources */,
 				01BB1D6D1F29999E004A912E /* PodcastPageViewController.swift in Sources */,
+				8F22502A2003440100FDF3F1 /* SharePodcastViewController.swift in Sources */,
 				162FFD401FBE200E0026288D /* DiskKeys.swift in Sources */,
 				16307FCC1F8FEE3A001783CB /* PodcastViewModelController.swift in Sources */,
 				16AD3E0E1F9B14130084C545 /* PodcastDataSource.swift in Sources */,
@@ -687,11 +694,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				1686FC161F009EC00088A6C1 /* SEDaily_IOSTests.swift in Sources */,
+				1686FC161F009EC00088A6C1 /* SEDailyIOSTests.swift in Sources */,
 				C0E64BB41FCB3F9100753AF0 /* UserModelTests.swift in Sources */,
 				C0E64BB71FCB406000753AF0 /* UserDefaultsMock.swift in Sources */,
 				C079B6541FCA07F800B4B304 /* HelpersTests.swift in Sources */,
-
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -856,7 +862,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 13;
-				DEVELOPMENT_TEAM = 6TY8WC8WPP;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "SEDaily-IOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "koala-tea.SEDaily";
@@ -876,7 +882,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 13;
-				DEVELOPMENT_TEAM = 6TY8WC8WPP;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "SEDaily-IOS/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "koala-tea.SEDaily";

--- a/SEDaily-IOS/Base.lproj/Localizable.strings
+++ b/SEDaily-IOS/Base.lproj/Localizable.strings
@@ -49,3 +49,4 @@
 "GenericOkay" = "Okay";
 "GenericOK" = "OK";
 "Play" = "Play";
+"Share" = "Share";

--- a/SEDaily-IOS/HeaderView.swift
+++ b/SEDaily-IOS/HeaderView.swift
@@ -8,6 +8,7 @@
 
 import UIKit
 import SwiftIcons
+import SwiftyBeaver
 
 protocol HeaderViewDelegate: class {
     func modelDidChange(viewModel: PodcastViewModel)
@@ -23,6 +24,9 @@ class HeaderView: UIView {
 
     let playView = UIView()
     let playButton = UIButton()
+    
+    let shareView = UIView()
+    let shareButtonCtrl = ShareButtonViewController()
 
     let voteView = UIView()
     let stackView = UIStackView()
@@ -81,38 +85,30 @@ class HeaderView: UIView {
     func setupPlayView() {
         self.addSubview(playView)
         playView.backgroundColor = Stylesheet.Colors.white
-
+        playView.addSubview(voteView)
+        voteView.addSubview(stackView)
+        playView.addSubview(playButton)
+        playView.addSubview(shareButtonCtrl.view)
+        
+        // container view for controls.
         playView.snp.makeConstraints { (make) in
             make.bottom.equalToSuperview()
             make.left.right.equalToSuperview()
             make.height.equalTo(UIView.getValueScaledByScreenHeightFor(baseValue: 65))
         }
-
-        playView.addSubview(playButton)
-        playButton.setTitle(L10n.play, for: .normal)
-        playButton.setBackgroundColor(color: Stylesheet.Colors.secondaryColor, forState: .normal)
-        playButton.addTarget(self, action: #selector(self.playButtonPressed), for: .touchUpInside)
-        playButton.cornerRadius = UIView.getValueScaledByScreenHeightFor(baseValue: 4)
-
-        playButton.snp.makeConstraints { (make) in
-            make.centerY.equalToSuperview()
-            make.right.equalToSuperview().inset(UIView.getValueScaledByScreenWidthFor(baseValue: 15))
-            make.width.equalTo(UIView.getValueScaledByScreenWidthFor(baseValue: 84))
-            make.height.equalTo(UIView.getValueScaledByScreenHeightFor(baseValue: 42))
-        }
-
-        playView.addSubview(voteView)
+        
+        // vote view.
+        //voteView.backgroundColor = UIColor.orange
         voteView.snp.makeConstraints { (make) in
             make.centerY.equalToSuperview()
             make.left.equalToSuperview().inset(UIView.getValueScaledByScreenWidthFor(baseValue: 15))
-            make.width.equalTo(UIView.getValueScaledByScreenWidthFor(baseValue: (35 * 3)))
             make.height.equalToSuperview()
         }
 
-        voteView.addSubview(stackView)
         stackView.snp.makeConstraints { (make) in
             make.edges.equalToSuperview()
         }
+        
         stackView.axis = .horizontal
         stackView.alignment = .fill
         stackView.distribution = .fillEqually
@@ -135,6 +131,27 @@ class HeaderView: UIView {
         upVoteButton.setIcon(icon: .fontAwesome(.thumbsUp), iconSize: iconSize, color: Stylesheet.Colors.base, forState: .selected)
         upVoteButton.setTitleColor(Stylesheet.Colors.secondaryColor, for: .selected)
         upVoteButton.addTarget(self, action: #selector(self.upvoteButtonPressed), for: .touchUpInside)
+        
+        // play button.
+        playButton.setTitle(L10n.play, for: .normal)
+        playButton.setBackgroundColor(color: Stylesheet.Colors.secondaryColor, forState: .normal)
+        playButton.addTarget(self, action: #selector(self.playButtonPressed), for: .touchUpInside)
+        playButton.cornerRadius = UIView.getValueScaledByScreenHeightFor(baseValue: 4)
+        playButton.snp.makeConstraints { (make) in
+            make.centerY.equalToSuperview()
+            make.right.equalTo(shareButtonCtrl.view.snp.left).inset(UIView.getValueScaledByScreenWidthFor(baseValue: -15))
+            make.width.equalTo(UIView.getValueScaledByScreenWidthFor(baseValue: 90))
+            make.height.equalTo(UIView.getValueScaledByScreenHeightFor(baseValue: 42))
+        }
+        
+        // share button.
+        shareButtonCtrl.view.snp.makeConstraints { (make) in
+            make.centerY.equalToSuperview()
+            make.right.equalToSuperview().inset(UIView.getValueScaledByScreenWidthFor(baseValue: 15))
+            make.width.equalTo(UIView.getValueScaledByScreenWidthFor(baseValue: 90))
+            make.height.equalTo(UIView.getValueScaledByScreenHeightFor(baseValue: 42))
+        }
+
     }
 
     func setupHeader(model: PodcastViewModel) {
@@ -142,6 +159,7 @@ class HeaderView: UIView {
         self.titleLabel.text = model.podcastTitle
         self.dateLabel.text = model.getLastUpdatedAsDate()?.dateString() ?? ""
         self.scoreLabel.text = model.score.string
+        self.shareButtonCtrl.shareObj = model.postLinkURL
 
         upVoteButton.isSelected = self.model.isUpvoted
         downVoteButton.isSelected = self.model.isDownvoted

--- a/SEDaily-IOS/HeaderView.swift
+++ b/SEDaily-IOS/HeaderView.swift
@@ -25,7 +25,6 @@ class HeaderView: UIView {
     let playView = UIView()
     let playButton = UIButton()
     
-    let shareView = UIView()
     let shareButtonCtrl = ShareButtonViewController()
 
     let voteView = UIView()

--- a/SEDaily-IOS/ShareButtonViewController.swift
+++ b/SEDaily-IOS/ShareButtonViewController.swift
@@ -19,7 +19,7 @@ class ShareButtonViewController: UIViewController {
         
         let button = UIButton()
         button.addTarget(self, action: #selector(self.shareButtonPressed), for: .touchUpInside)
-        button.setTitle("Share", for: .normal)
+        button.setTitle(L10n.share, for: .normal)
         button.setBackgroundColor(color: Stylesheet.Colors.shareButtonDefault, forState: .normal)
         button.cornerRadius = UIView.getValueScaledByScreenHeightFor(baseValue: 4)
         
@@ -27,7 +27,13 @@ class ShareButtonViewController: UIViewController {
     }
     
     @objc func shareButtonPressed() {
+        
         SwiftyBeaver.info("Share UI Button Pressed")
+        if ( shareObj == nil ) {
+            SwiftyBeaver.warning("shareObj is nil.  taking no action")
+            return
+        }
+        
         let shareUI = SharePodcastViewController(activityItems: [shareObj!], applicationActivities: nil)
         
         shareUI.modalPresentationStyle = .popover

--- a/SEDaily-IOS/ShareButtonViewController.swift
+++ b/SEDaily-IOS/ShareButtonViewController.swift
@@ -1,0 +1,42 @@
+//
+//  ShareButton.swift
+//  SEDaily-IOS
+//
+//  Created by Joseph Carson on 1/9/18.
+//  Copyright © 2018 Koala Tea. All rights reserved.
+//
+
+import Foundation
+import SwiftyBeaver
+import UIKit
+
+class ShareButtonViewController: UIViewController {
+    
+    // The object to share.
+    public var shareObj: Any?
+    
+    @objc override func loadView() {
+        
+        let button = UIButton()
+        button.addTarget(self, action: #selector(self.shareButtonPressed), for: .touchUpInside)
+        button.setTitle("Share", for: .normal)
+        button.setBackgroundColor(color: Stylesheet.Colors.shareButtonDefault, forState: .normal)
+        button.cornerRadius = UIView.getValueScaledByScreenHeightFor(baseValue: 4)
+        
+        view = button
+    }
+    
+    @objc func shareButtonPressed() {
+        SwiftyBeaver.info("Share UI Button Pressed")
+        let shareUI = SharePodcastViewController(activityItems: [shareObj!], applicationActivities: nil)
+        
+        shareUI.modalPresentationStyle = .popover
+        shareUI.completionWithItemsHandler = { (activityType: UIActivityType?, completed: Bool, returnedItems: [Any]?, activityError: Error?) -> Void in
+            SwiftyBeaver.info("Share UI Complete error: \(String(describing: activityError))")
+        }
+        
+        let pop = shareUI.popoverPresentationController
+        pop!.sourceView = self.view
+        self.present(shareUI, animated: true, completion: nil)
+    }
+}

--- a/SEDaily-IOS/SharePodcastViewController.swift
+++ b/SEDaily-IOS/SharePodcastViewController.swift
@@ -1,0 +1,18 @@
+//
+//  SharePodcastViewController.swift
+//  SEDaily-IOS
+//
+//  Created by Joseph Carson on 1/7/18.
+//  Copyright © 2018 Koala Tea. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+class SharePodcastViewController: UIActivityViewController {
+    
+    override init(activityItems: [Any], applicationActivities: [UIActivity]?) {
+        super.init(activityItems: activityItems, applicationActivities: applicationActivities)
+    }
+    
+}

--- a/SEDaily-IOS/Stylesheet.swift
+++ b/SEDaily-IOS/Stylesheet.swift
@@ -31,6 +31,8 @@ enum Stylesheet {
 
         static let secondaryColor = UIColor(hex: 0xfc4482)!
         static let bufferColor = UIColor(hex: 0xb6b8b9)!
+        
+        static let shareButtonDefault = UIColor.blue
     }
 
     enum Fonts {


### PR DESCRIPTION
Add basic share button functionality as a reusable UIViewController that manages a UIButton.  At the moment the only thing that is shared is the podcast URL but it can be extended by the caller to include more information if desired.