### PR TITLE
Add new features view on app update

### DIFF
--- a/Constants/L10nEnum.swift
+++ b/Constants/L10nEnum.swift
@@ -153,6 +153,10 @@ enum L10n {
   static let usernameOrEmailPlaceholder = L10n.tr("Localizable", "UsernameOrEmailPlaceholder")
   /// Username
   static let usernamePlaceholder = L10n.tr("Localizable", "UsernamePlaceholder")
+  /// - Offline downloads - Take SEDaily with you everywhere :D\n- Bookmark fixes\n- Local notifications - If you need a reminder to listen to all of our amazing content
+  static let whatsNewBody = L10n.tr("Localizable", "WhatsNewBody")
+  /// Here's what's new in this app update!
+  static let whatsNewHeader = L10n.tr("Localizable", "WhatsNewHeader")
 }
 // swiftlint:enable explicit_type_interface identifier_name line_length nesting type_body_length type_name
 

--- a/Podfile
+++ b/Podfile
@@ -7,8 +7,8 @@ target 'SEDaily-IOS' do
 
   # Pods for SEDaily-IOS
   pod 'ActiveLabel', :git => 'https://github.com/optonaut/ActiveLabel.swift.git'
-p
   pod 'Alamofire', '~> 4.5.1'
+  pod 'Bumper', '~> 0.1.0'
   pod 'Crashlytics', '~> 3.9.3'
   pod 'Down'
   pod 'Disk', '~> 0.3.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,7 @@
 PODS:
   - ActiveLabel (0.8.1)
   - Alamofire (4.5.1)
+  - Bumper (0.1.0)
   - Crashlytics (3.9.3):
     - Fabric (~> 1.7.2)
   - Disk (0.3.3)
@@ -88,6 +89,7 @@ PODS:
 DEPENDENCIES:
   - ActiveLabel (from `https://github.com/optonaut/ActiveLabel.swift.git`)
   - Alamofire (~> 4.5.1)
+  - Bumper (~> 0.1.0)
   - Crashlytics (~> 3.9.3)
   - Disk (~> 0.3.1)
   - Down
@@ -124,8 +126,9 @@ DEPENDENCIES:
   - WaitForIt (~> 2.0.0)
 
 SPEC REPOS:
-  https://github.com/CocoaPods/Specs.git:
+  https://github.com/cocoapods/specs.git:
     - Alamofire
+    - Bumper
     - Crashlytics
     - Disk
     - Down
@@ -184,6 +187,7 @@ CHECKOUT OPTIONS:
 SPEC CHECKSUMS:
   ActiveLabel: 2fc3cdffed0dcdaad82d50af46233b9ef2f401e4
   Alamofire: 2d95912bf4c34f164fdfc335872e8c312acaea4a
+  Bumper: a4e21282b402b5ffbd482655d4f62d3fa5c86751
   Crashlytics: dbb07d01876c171c5ccbdf7826410380189e452c
   Disk: d1f55cd61f6ca20f368232d0c6e37e3c3dfcb63e
   Down: 6ace44ecec0c408826342ed420002f39a18e38c3
@@ -225,6 +229,6 @@ SPEC CHECKSUMS:
   URITemplate: ace0c4c46dcf8afe6e89b4060621852886b15c3b
   WaitForIt: 2c7ad6deaffe3bf727b7242a2263167bf2ce3e57
 
-PODFILE CHECKSUM: 900e14f47cd2ee536f721b3001b6397437682697
+PODFILE CHECKSUM: a01b7294d8d9c2506218b0a32829d2212cac069b
 
-COCOAPODS: 1.5.0
+COCOAPODS: 1.5.2

--- a/SEDaily-IOS.xcodeproj/project.pbxproj
+++ b/SEDaily-IOS.xcodeproj/project.pbxproj
@@ -859,6 +859,7 @@
 				"${SRCROOT}/Pods/Target Support Files/Pods-SEDaily-IOS/Pods-SEDaily-IOS-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/ActiveLabel/ActiveLabel.framework",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${BUILT_PRODUCTS_DIR}/Bumper/Bumper.framework",
 				"${BUILT_PRODUCTS_DIR}/Disk/Disk.framework",
 				"${BUILT_PRODUCTS_DIR}/Down/Down.framework",
 				"${BUILT_PRODUCTS_DIR}/Eureka/Eureka.framework",
@@ -892,6 +893,7 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ActiveLabel.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Bumper.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Disk.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Down.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Eureka.framework",

--- a/SEDaily-IOS/AppDelegate.swift
+++ b/SEDaily-IOS/AppDelegate.swift
@@ -15,6 +15,7 @@ import Crashlytics
 import Kingfisher
 //import Stripe
 import Firebase
+import Bumper
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -27,6 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Fabric.with([Crashlytics.self])
         setupSwiftyBeaver()
         setupIQKeyboard()
+        setupBumper()
         setupFirstScreen()
 
         // Max size for Kingfisher ImageCache
@@ -72,6 +74,10 @@ extension AppDelegate {
 
     func setupIQKeyboard() {
         IQKeyboardManager.sharedManager().enable = true
+    }
+
+    func setupBumper() {
+        Bumper.launch()
     }
 
     func setupFirstScreen() {

--- a/SEDaily-IOS/Base.lproj/Localizable.strings
+++ b/SEDaily-IOS/Base.lproj/Localizable.strings
@@ -80,3 +80,7 @@
 "Search" = "Search";
 "EmptySearch" = "No results for search";
 "FetchingSearch" = "Fetching results";
+"WhatsNewHeader" = "Here's what's new in this app update!";
+"WhatsNewBody" = "- Offline downloads - Take SEDaily with you everywhere :D
+- Bookmark fixes
+- Local notifications - If you need a reminder to listen to all of our amazing content";

--- a/SEDaily-IOS/CustomTabViewController.swift
+++ b/SEDaily-IOS/CustomTabViewController.swift
@@ -14,6 +14,7 @@ import StoreKit
 import SwifterSwift
 import SwiftIcons
 import Firebase
+import Bumper
 
 class CustomTabViewController: UITabBarController, UITabBarControllerDelegate {
 
@@ -44,6 +45,17 @@ class CustomTabViewController: UITabBarController, UITabBarControllerDelegate {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         setupNavBar()
+
+        // Display the what's new dialog if the app was updated and there is
+        // content to show
+        if L10n.whatsNewBody.length > 0 {
+            Bumper.tryToExecute {
+                let whatsNewPopup = PopupDialog(title: L10n.whatsNewHeader, message: L10n.whatsNewBody)
+                let okayButton = DefaultButton(title: L10n.genericOkay, action: nil)
+                whatsNewPopup.addButton(okayButton)
+                self.present(whatsNewPopup, animated: true, completion: nil)
+            }
+        }
 
         AskForReview.tryToExecute { didExecute in
             if didExecute {


### PR DESCRIPTION
#24 

In this PR I've added [Bumper](https://github.com/eddies5/Bumper) which will detect app updates and execute a custom closure. In this closure I used [PopupDialog](https://github.com/Orderella/PopupDialog) to display a what's new view of the latest updates to the app. PopupDialog allows for view customization if you'd like to update the appearance of the default popup.

Please update Localizable.strings to the copy you prefer before merging this in. I simply grabbed the release notes from the last app update as placeholder text.